### PR TITLE
Switch to compose binary instead of container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 - Switched from Traefik proxy to Caddy proxy, for simpler config
 - Remove Lets Encrypt email settings and instead rely on Caddy's default auto-HTTPS
+- Use `docker compose` binary instead of compose container
 
 ### [1.2.1](https://github.com/christippett/terraform-cloudinit-container-server/compare/v1.2.0...v1.2.1) (2021-04-14)
 

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -21,18 +21,9 @@ write_files:
       RemainAfterExit=yes
       WorkingDirectory=/var/app
       EnvironmentFile=/var/app/.env
-      ExecStartPre=-/usr/bin/docker run --rm \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -v "/var/app:/var/app" -w "/var/app" \
-        "$${COMPOSE_DOCKER_IMAGE}:$${COMPOSE_DOCKER_TAG}" -f ${c.filename} pull --ignore-pull-failures
-      ExecStart=/usr/bin/docker run --rm \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -v "/var/app:/var/app" -w "/var/app" \
-        "$${COMPOSE_DOCKER_IMAGE}:$${COMPOSE_DOCKER_TAG}" -f ${c.filename} up -d
-      ExecStop=/usr/bin/docker run --rm \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -v "/var/app:/var/app" -w "/var/app" \
-        "$${COMPOSE_DOCKER_IMAGE}:$${COMPOSE_DOCKER_TAG}" -f ${c.filename} down -t 15
+      ExecStartPre=-docker compose -f ${c.filename} pull --ignore-pull-failures
+      ExecStart=docker compose -f ${c.filename} up -d
+      ExecStop=docker compose -f ${c.filename} down -t 15
 
       [Install]
       WantedBy=multi-user.target

--- a/templates/cloud-config.yaml
+++ b/templates/cloud-config.yaml
@@ -15,6 +15,7 @@ write_files:
       Description=Docker Compose Service (${coalesce(c.name, "app")})
       Requires=docker.service ${join(" ", [ for f in docker_compose_files : "${f.name}.service" if f.name != null && c.name == null ])}
       After=docker.service
+      ${ c.name == "caddy" ? "" : "Before=caddy.service" }
 
       [Service]
       Type=oneshot
@@ -58,10 +59,19 @@ write_files:
       WantedBy=multi-user.target
 
 runcmd:
-  # Install Docker if required. Note: This installation method is not
-  # recommended for production deployments
-  # https://github.com/docker/docker-install
-  - which docker > /dev/null 2>&1 || curl -fsSL https://get.docker.com | sh
+  # Install Docker in a production-stable way
+  # now that we are on a known-constant distro across all providers
+  # from https://docs.docker.com/engine/install/ubuntu/
+  - apt-get -qq update -y
+  - apt-get -qq install -y ca-certificates curl gnupg lsb-release
+  - mkdir -p /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  # create apt sources file here instead of in write_files to prevent unsigned repo error in initial apt update
+  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+  - apt-get -qq update -y
+  - apt-get -qq install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+  - systemctl enable --now docker.socket
+
   # Create network used by Traefik to identify running containers
   - "[ $(docker network list -q --filter=name=web) ] || docker network create web"
 %{ if login != null }


### PR DESCRIPTION
Now that we are switching to using Ubuntu images across all cloud providers, we can install `docker compose` on all systems, and not need to rely on the `docker/compose` container -- looking at you, GCOS.

Also see: https://gitlab.com/onecommons/unfurl-types/-/merge_requests/37